### PR TITLE
Standardize code replacement strings - ASP .NET quickstart

### DIFF
--- a/AppModelv2-WebApp-OpenIDConnect-DotNet/Web.config
+++ b/AppModelv2-WebApp-OpenIDConnect-DotNet/Web.config
@@ -11,7 +11,7 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
 
     <add key="ClientId" value="Enter_the_Application_Id_here" />
-    <add key="Tenant" value="common" />
+    <add key="Tenant" value="Enter_the_Tenant_Info_Here" />
     
     <add key="Authority" value="https://login.microsoftonline.com/{0}/v2.0" />    
     <add key="redirectUri" value="https://localhost:44368/" />


### PR DESCRIPTION
We have a working prototype to improve developer experience in quickstarts so that the downloaded code sample is ready-to-run and no longer needs manual step of copy-pasting the code blob with clientId/password/etc info. For that, we're standardizing code replacement strings as follows:
ClientIdStringToReplace : "Enter_the_Application_Id_here"
ClientTenantToReplace : "Enter_the_Tenant_Info_Here"
ClientSecretToReplace": "Enter_the_Client_Secret_Here"
BundleIdToReplace : "Enter_the_Bundle_Id_Here"
RedirectUriToReplace : "Enter_the_Redirect_URI_Here"
PackageNameToReplace : "Enter_the_Package_Name_Here"
SignatureHashToReplace : "Enter_the_Signature_Hash_Here"