### PR TITLE
Corrected the git clone URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This sample demonstrates a ASP.NET web app application that authenticates users 
 From your shell or command line:
 
 ```console
-git clone https://github.com/Azure-Samples/AppModelv2-WebApp-OpenIDConnect-DotNet.git
+git clone https://github.com/AzureADQuickStarts/AppModelv2-WebApp-OpenIDConnect-DotNet.git
 cd AppModelv2-WebApp-OpenIDConnect-DotNet
 ```
 


### PR DESCRIPTION
I've corrected the URI used for the git clone line in the readme, it pointed to a path that no longer exists, probably because the project has been moved to a new organization?